### PR TITLE
Fix for v3 Password authentication with scoped authorization

### DIFF
--- a/lib/miasma/contrib/open_stack.rb
+++ b/lib/miasma/contrib/open_stack.rb
@@ -116,7 +116,7 @@ module Miasma
 
         end
 
-        # Authentication implementation compatible for v2
+        # Authentication implementation compatible for v3
         class Version3 < Authenticate
 
           # @return [Smash] authentication request body
@@ -155,17 +155,13 @@ module Miasma
                 )
               )
             else
-              if(credentials[:open_stack_domain])
+              if(credentials[:open_stack_domain] and credentials[:open_stack_project])
                 scope = Smash.new(
-                  :domain => Smash.new(
-                    :name => credentials[:open_stack_domain]
+                  :project => Smash.new(
+                    :name => credentials[:open_stack_project],
+                    :domain => { :name => credentials[:open_stack_domain] }
                   )
                 )
-                if(credentials[:open_stack_project])
-                  scope[:project] = Smash.new(
-                    :name => credentials[:open_stack_project]
-                  )
-                end
               end
             end
             auth = Smash.new(:identity => ident)
@@ -186,7 +182,7 @@ module Miasma
                 :auth => authentication_request
               )
             )
-            unless(result.status == 200)
+            unless(result.status == 200 or result.status == 201)
               raise Error::ApiError::AuthenticationError.new('Failed to authenticate!', result)
             end
             info = MultiJson.load(result.body.to_s).to_smash[:token]

--- a/lib/miasma/contrib/open_stack.rb
+++ b/lib/miasma/contrib/open_stack.rb
@@ -143,9 +143,7 @@ module Miasma
             if(credentials[:open_stack_token])
               ident[:methods] << 'token'
               ident[:token] = Smash.new(
-                :token => Smash.new(
                   :id => credentials[:open_stack_token]
-                )
               )
             end
             if(credentials[:open_stack_project_id])


### PR DESCRIPTION
Identity API v3 returns HTTP 201 when new token is generated

https://developer.openstack.org/api-ref/identity/v3/?expanded=#password-authentication-with-scoped-authorization

and scoped authorization with project name requires a nested domain name

Example: https://books.google.de/books?id=nZYpCwAAQBAJ&pg=PT26

Unfortunately I can't test other auth methods but this fix made sparkleformation cli working with OpenStack API. 