### PR TITLE
openstack keyston v3 API format 

### DIFF
--- a/lib/miasma/contrib/open_stack.rb
+++ b/lib/miasma/contrib/open_stack.rb
@@ -163,7 +163,7 @@ module Miasma
                 )
                 if(credentials[:open_stack_domain])
                   scope[:project][:domain] = Smash.new(
-                    :nameg => credentials[:open_stack_domain]
+                    :name => credentials[:open_stack_domain]
                   )
                 end
               end

--- a/lib/miasma/contrib/open_stack.rb
+++ b/lib/miasma/contrib/open_stack.rb
@@ -155,15 +155,15 @@ module Miasma
                 )
               )
             else
-              if(credentials[:open_stack_domain])
+              if(credentials[:open_stack_project])
                 scope = Smash.new(
-                  :domain => Smash.new(
-                    :name => credentials[:open_stack_domain]
+                  :project => Smash.new(
+                    :name => credentials[:open_stack_project]
                   )
                 )
-                if(credentials[:open_stack_project])
-                  scope[:project] = Smash.new(
-                    :name => credentials[:open_stack_project]
+                if(credentials[:open_stack_domain])
+                  scope[:project][:domain] = Smash.new(
+                    :nameg => credentials[:open_stack_domain]
                   )
                 end
               end
@@ -186,7 +186,7 @@ module Miasma
                 :auth => authentication_request
               )
             )
-            unless(result.status == 200)
+            unless(result.status == 200 || result.status == 201)
               raise Error::ApiError::AuthenticationError.new('Failed to authenticate!', result)
             end
             info = MultiJson.load(result.body.to_s).to_smash[:token]
@@ -314,7 +314,9 @@ module Miasma
         end
         if(region)
           point = srv[:endpoints].detect do |endpoint|
-            endpoint[:region].to_s.downcase == region.to_s.downcase
+            if(endpoint[:interface].to_s.downcase == "public")
+                endpoint[:region].to_s.downcase == region.to_s.downcase
+            end
           end
         else
           point = srv[:endpoints].first


### PR DESCRIPTION
 - keystone v3 api expects domain inside project for scope, make sure to use public URL
```
"scope": {
      "project": {
        "name": "demo",
        "domain": { "id": "e73bb4bfe82940489f271cf96abf1528" }
      }
```
or
```
"scope": {
      "project": {
        "name": "demo",
        "domain": { "name": "foo" }
      }
```

also the `public` URL is the one we want as the internal API URLs may not be reachable for users.

Given the below list of `srv[:endpoints]`  we want public as `192...` is not reachable

```
{"url"=>"http://192.168.200.4:8004/v1/e9a2869893734aab8061c0ebb10e0876", "interface"=>"admin", "region"=>"RegionOne", "region_id"=>"RegionOne", "id"=>"6167aa49816642fca39c3cef4cacf9f0"}
{"url"=>"https://cloud.corp.com:8004/v1/e9a2869893734aab8061c0ebb10e0876", "interface"=>"public", "region"=>"RegionOne", "region_id"=>"RegionOne", "id"=>"d71643b135754519bbf6425a27bc6926"}
{"url"=>"http://192.168.200.4:8004/v1/e9a2869893734aab8061c0ebb10e0876", "interface"=>"internal", "region"=>"RegionOne", "region_id"=>"RegionOne", "id"=>"f754d907d5ce466b88658fe797e09822"}
{"url"=>"https://cloud.corp.com:8004/v1/e9a2869893734aab8061c0ebb10e0876", "interface"=>"public", "region"=>"RegionOne", "region_id"=>"RegionOne", "id"=>"d71643b135754519bbf6425a27bc6926"}
```
